### PR TITLE
Bug with Dataset Generation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -101,7 +101,7 @@ train-bipedal:
 train-car:     ENV=$(CAR_ENV)
 train-car:
 	@echo "Training $(ENV) with $(ALGO)..."
-	python -m rl_zoo3.train --algo $(ALGO) --env $(ENV) --track --wandb-project-name $(WANDB_PROJECT) --wandb-entity $(HF_ORG) --hyperparams frame_stack:3 n_timesteps:1e5
+	python -m rl_zoo3.train --algo $(ALGO) --env $(ENV) --track --wandb-project-name $(WANDB_PROJECT) --wandb-entity $(HF_ORG)
 train-all: train-lunar train-bipedal train-car
 
 # --- Evaluation ---

--- a/Makefile
+++ b/Makefile
@@ -137,6 +137,7 @@ generate-bipedal-dataset: generate-dataset
 generate-car-dataset: ENV=$(CAR_ENV)
 generate-car-dataset: generate-dataset
 
+generate-all-datasets: generate-lunar-dataset generate-bipedal-dataset generate-car-dataset
 # --- Dataset pushing ---
 push-lunar-dataset:    ENV=$(LUNAR_ENV)
 push-lunar-dataset:    push-dataset

--- a/src/pipelines/collect_dataset.py
+++ b/src/pipelines/collect_dataset.py
@@ -37,7 +37,7 @@ def generate_dataset(args):
         render_mode="rgb_array",  # change to human for debugging.
         continuous=True,
     )
-    env = DataCollector(minari_env)
+    data_collector = DataCollector(minari_env)
     if "env_wrapper" in hyperparams:
         for wrapper_config in hyperparams["env_wrapper"]:
             wrapper_name = list(wrapper_config.keys())[0]
@@ -45,7 +45,7 @@ def generate_dataset(args):
             if "grayscaleobservation" in wrapper_name.lower():
                 wrapper_config[wrapper_name]["keep_dim"] = False
         wrapper_class = get_wrapper_class(hyperparams=hyperparams, key="env_wrapper")
-        minari_env = wrapper_class(minari_env)
+        minari_env = wrapper_class(data_collector)
 
     if "frame_stack" in hyperparams:
         n_stack = hyperparams["frame_stack"]
@@ -58,17 +58,16 @@ def generate_dataset(args):
             action, _ = agent.predict(obs, deterministic=True)
             obs, rew, terminated, truncated, info = minari_env.step(action)
             if terminated or truncated:
-                print("Episode finished.")
                 break
 
-    dataset = env.create_dataset(
+    dataset = data_collector.create_dataset(
         dataset_id=f"Box2D/{args.env}/{args.level}-v{args.version}",
         algorithm_name=args.algo,
         code_permalink="https://github.com/frankcholula/flow_planner",
         author="Frank Lu",
         author_email="lu.phrank@gmail.com",
         description=f"Behavioral cloning dataset for {args.env} using {args.algo}",
-        eval_env=args.env,
+        eval_env=minari_env,
     )
 
 

--- a/src/pipelines/collect_dataset.py
+++ b/src/pipelines/collect_dataset.py
@@ -17,9 +17,31 @@ from gymnasium.wrappers import (
 
 import os
 import torch
-import numpy as np
 
 ALGOS = {"ppo": PPO, "ppo_lstm": PPO, "a2c": A2C, "td3": TD3}
+
+
+def make_env(env_name, hyperparams):
+    env_kwargs = {"render_mode": "rgb_array"}
+    if env_name in ["LunarLanderContinuous-v3", "CarRacing-v3"]:
+        env_kwargs.update({"continuous": True})
+    env = gym.make(env_name, **env_kwargs)
+    data_collector = DataCollector(env)
+    if "env_wrapper" in hyperparams:
+        print("Wrapping environment with custom wrappers")
+        for wrapper_config in hyperparams["env_wrapper"]:
+            wrapper_name = list(wrapper_config.keys())[0]
+            # some janky replacement because of the gymnasium implementation of FrameStack
+            if "grayscaleobservation" in wrapper_name.lower():
+                wrapper_config[wrapper_name]["keep_dim"] = False
+        wrapper_class = get_wrapper_class(hyperparams=hyperparams, key="env_wrapper")
+        env = wrapper_class(data_collector)
+
+    if "frame_stack" in hyperparams:
+        print("Wrapping environment with FrameStackObservation")
+        n_stack = hyperparams["frame_stack"]
+        env = FrameStackObservation(env, n_stack)
+    return env, data_collector
 
 
 def generate_dataset(args):
@@ -31,26 +53,7 @@ def generate_dataset(args):
     )
     stats_path = os.path.join(log_path, f"{args.env}")
     hyperparams, _ = get_saved_hyperparams(stats_path=stats_path, test_mode=True)
-    minari_env = gym.make(
-        args.env,
-        **hyperparams.get("env_kwargs", {}),
-        render_mode="rgb_array",  # change to human for debugging.
-        continuous=True,
-    )
-    data_collector = DataCollector(minari_env)
-    if "env_wrapper" in hyperparams:
-        for wrapper_config in hyperparams["env_wrapper"]:
-            wrapper_name = list(wrapper_config.keys())[0]
-            # some janky replacement because of the gymnasium implementation of FrameStack
-            if "grayscaleobservation" in wrapper_name.lower():
-                wrapper_config[wrapper_name]["keep_dim"] = False
-        wrapper_class = get_wrapper_class(hyperparams=hyperparams, key="env_wrapper")
-        minari_env = wrapper_class(data_collector)
-
-    if "frame_stack" in hyperparams:
-        n_stack = hyperparams["frame_stack"]
-        minari_env = FrameStackObservation(minari_env, n_stack)
-
+    minari_env, data_collector = make_env(args.env, hyperparams)
     agent = ALGOS[args.algo].load(model_path, env=minari_env)
     for i in tqdm(range(args.total_episodes), desc="Collecting episodes"):
         obs, _ = minari_env.reset()

--- a/src/pipelines/collect_dataset.py
+++ b/src/pipelines/collect_dataset.py
@@ -13,7 +13,6 @@ from rl_zoo3.utils import (
 import gymnasium as gym
 from gymnasium.wrappers import (
     FrameStackObservation,
-    TransformObservation,
 )
 
 import os
@@ -38,6 +37,7 @@ def generate_dataset(args):
         render_mode="rgb_array",  # change to human for debugging.
         continuous=True,
     )
+    env = DataCollector(minari_env)
     if "env_wrapper" in hyperparams:
         for wrapper_config in hyperparams["env_wrapper"]:
             wrapper_name = list(wrapper_config.keys())[0]
@@ -50,25 +50,14 @@ def generate_dataset(args):
     if "frame_stack" in hyperparams:
         n_stack = hyperparams["frame_stack"]
         minari_env = FrameStackObservation(minari_env, n_stack)
-        # TODO: This is to avoid the stupid image compression by minari
-        new_obs_space = gym.spaces.Box(
-            low=0, high=255, shape=minari_env.observation_space.shape, dtype=np.float32
-        )
-        minari_env = TransformObservation(
-            env=minari_env,
-            func=lambda obs: obs.astype(np.float32),
-            observation_space=new_obs_space,
-        )
 
-    agent = ALGOS[args.algo].load(model_path)
-    env = DataCollector(minari_env)
-    for i in tqdm(range(args.total_episodes)):
-        obs, _ = env.reset(seed=args.seed)
+    agent = ALGOS[args.algo].load(model_path, env=minari_env)
+    for i in tqdm(range(args.total_episodes), desc="Collecting episodes"):
+        obs, _ = minari_env.reset()
         while True:
             action, _ = agent.predict(obs, deterministic=True)
-            obs, rew, terminated, truncated, info = env.step(action)
+            obs, rew, terminated, truncated, info = minari_env.step(action)
             if terminated or truncated:
-                print(obs, rew, terminated, truncated, info)
                 print("Episode finished.")
                 break
 


### PR DESCRIPTION
This pull request refactors the dataset collection pipeline to improve environment creation and dataset generation, and introduces a new Makefile target for generating all datasets. The main changes focus on modularizing environment setup and simplifying the dataset generation process.

**Pipeline refactor and environment setup:**
- Refactored `src/pipelines/collect_dataset.py` by extracting environment creation logic into a new `make_env` function, which handles environment instantiation and wrapper application more cleanly. The dataset collection loop now interacts directly with the wrapped environment and data collector, improving clarity and maintainability.

**Makefile improvements:**
- Added a new `generate-all-datasets` target to the `Makefile`, enabling generation of all datasets with a single command.

**Simplification and cleanup:**
- Removed unnecessary hyperparameters (`frame_stack` and `n_timesteps`) from the `train-car` target in the `Makefile` to streamline training command usage.