### PR TITLE
Refactor training into modular helpers

### DIFF
--- a/src/run.py
+++ b/src/run.py
@@ -25,12 +25,9 @@ from src.pipelines.eval import evaluate_open_loop, evaluate_policy_mpc
 from matplotlib import pyplot as plt
 
 
-def train(config, args, dataset, logger):
-    # parsing some configs
-    obs_dim = config.obs_dim
-    action_dim = config.action_dim
+def build_model(args, obs_dim, action_dim):
     horizon = args.horizon
-    if args.chunk_type == "obs_act":        
+    if args.chunk_type == "obs_act":
         input_dim = (obs_dim + action_dim) * horizon
     elif args.chunk_type == "obs_only":
         input_dim = obs_dim * horizon
@@ -40,20 +37,6 @@ def train(config, args, dataset, logger):
         raise ValueError(f"Invalid chunk_type: {args.chunk_type}")
     print(f"Input dimension for the model: {input_dim}")
 
-    # load the dataset and stats based on config
-    generator = None
-    if args.device == "cuda":
-        generator = torch.Generator(device=args.device)
-    dataloader = DataLoader(
-        dataset,
-        batch_size=args.batch_size,
-        shuffle=True,
-        collate_fn=collate_fn,
-        generator=generator,
-    )
-    stats = get_dataset_stats(dataset)
-
-    # Setting up models
     if args.model_type == "mlp":
         model = MLP(input_dim=input_dim, time_dim=1, hidden_dim=args.hidden_dim).to(
             args.device
@@ -74,8 +57,7 @@ def train(config, args, dataset, logger):
             cond_dim = obs_dim * 2
         else:
             raise ValueError(
-                f"ConditionalCNN requires a valid --condition-on argument ('reward', 'start_obs', 'start_obs_goal'), "
-                f"but got: {args.condition_on}"
+                "ConditionalCNN requires a valid --condition-on argument ('reward', 'start_obs', 'start_obs_goal')"
             )
         model = ConditionalCNN(
             input_dim=input_dim,
@@ -94,8 +76,7 @@ def train(config, args, dataset, logger):
             cond_dim = obs_dim * 2
         else:
             raise ValueError(
-                f"UNet1D requires a valid --condition-on argument ('reward', 'start_obs', 'start_obs_goal'), "
-                f"but got: {args.condition_on}"
+                "UNet1D requires a valid --condition-on argument ('reward', 'start_obs', 'start_obs_goal')"
             )
         model = ConditionalUNet1D(
             input_dim=input_dim,
@@ -105,10 +86,76 @@ def train(config, args, dataset, logger):
             fusion_strategy="concat",
             use_mlp_embedding=False,
         ).to(args.device)
+    else:
+        raise ValueError(f"Invalid model_type: {args.model_type}")
+    return model, input_dim
+
+
+def build_dataloader(dataset, args):
+    generator = torch.Generator(device=args.device) if args.device == "cuda" else None
+    dataloader = DataLoader(
+        dataset,
+        batch_size=args.batch_size,
+        shuffle=True,
+        collate_fn=collate_fn,
+        generator=generator,
+    )
+    stats = get_dataset_stats(dataset)
+    return dataloader, stats
+
+
+def run_epoch(model, dataloader, path, optim, args, stats):
+    total_loss = 0.0
+    total_chunks = 0
+    for batch in dataloader:
+        optim.zero_grad()
+
+        if args.condition_on:
+            x1, c = create_normalized_chunks(
+                batch,
+                args.horizon,
+                stats,
+                cond_type=args.condition_on,
+                chunk_type=args.chunk_type,
+            )
+            if x1 is None:
+                continue
+            x1, c = x1.to(args.device), c.to(args.device)
+        else:
+            x1 = create_normalized_chunks(
+                batch, args.horizon, stats, chunk_type=args.chunk_type
+            )
+            if x1 is None:
+                continue
+            x1 = x1.to(args.device)
+
+        x0 = torch.randn_like(x1)
+        t = torch.rand(x1.shape[0], device=args.device)
+        sample = path.sample(t=t, x_0=x0, x_1=x1)
+
+        if args.condition_on:
+            pred = model(sample.x_t, sample.t, c=c)
+        else:
+            pred = model(sample.x_t, sample.t)
+
+        loss = torch.pow(pred - sample.dx_t, 2).mean()
+        loss.backward()
+        optim.step()
+        total_loss += loss.item()
+        total_chunks += 1
+
+    return total_loss / total_chunks if total_chunks > 0 else 0.0
+
+
+def train(config, args, dataset, logger):
+    obs_dim = config.obs_dim
+    action_dim = config.action_dim
+
+    model, input_dim = build_model(args, obs_dim, action_dim)
+    dataloader, stats = build_dataloader(dataset, args)
     path = AffineProbPath(scheduler=CondOTScheduler())
     optim = torch.optim.Adam(model.parameters(), lr=args.lr)
 
-    # checkpoints and model saving
     model_name = logger.run.name + ".pth"
     save_dir = "src/checkpoints"
     model_save_path = os.path.join(save_dir, model_name)
@@ -120,56 +167,15 @@ def train(config, args, dataset, logger):
     print("Starting training...")
 
     for epoch in range(args.num_epochs):
-        total_loss = 0.0
-        total_chunks = 0
         start_time = time.time()
-        for batch in dataloader:
-            optim.zero_grad()
-
-            if args.condition_on:
-                x1, c = create_normalized_chunks(
-                    batch,
-                    args.horizon,
-                    stats,
-                    cond_type=args.condition_on,
-                    chunk_type=args.chunk_type,
-                )
-                if x1 is None:
-                    continue
-                x1, c = x1.to(args.device), c.to(args.device)
-            else:
-                x1 = create_normalized_chunks(
-                    batch, args.horizon, stats, chunk_type=args.chunk_type
-                )
-                if x1 is None:
-                    continue
-                x1 = x1.to(args.device)
-
-            x0 = torch.randn_like(x1)
-            t = torch.rand(x1.shape[0], device=args.device)
-            sample = path.sample(t=t, x_0=x0, x_1=x1)
-
-            if args.condition_on:
-                pred = model(sample.x_t, sample.t, c=c)
-            else:
-                pred = model(sample.x_t, sample.t)
-
-            loss = torch.pow(pred - sample.dx_t, 2).mean()
-            # for debugging
-            # print(f"Epoch {epoch+1}, Batch Loss: {loss.item():.4f}")
-            loss.backward()
-            optim.step()
-            total_loss += loss.item()
-            total_chunks += 1
-
-        epoch_loss = total_loss / total_chunks if total_chunks > 0 else 0.0
+        epoch_loss = run_epoch(model, dataloader, path, optim, args, stats)
         logger.log({"epoch loss": epoch_loss})
         if (epoch + 1) % args.print_every == 0:
             elapsed = time.time() - start_time
             print(
                 f"| Epoch {epoch+1:6d} | {elapsed:.2f} s/epoch | Loss {epoch_loss:8.5f} |"
             )
-            start_time = time.time()
+
     print("Training complete. Saving model...")
     os.makedirs(save_dir, exist_ok=True)
     torch.save(model.state_dict(), model_save_path)


### PR DESCRIPTION
## Summary
- add `build_model` to create model from CLI args
- add `build_dataloader` for dataset loading and stats
- add `run_epoch` and simplify `train`

## Testing
- `python3 -m py_compile src/run.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68a2500499c88327ba27c148e4fc6ceb