### PR TITLE
Add chunk type and evaluation options

### DIFF
--- a/src/run.py
+++ b/src/run.py
@@ -21,11 +21,11 @@ from src.pipelines.preprocessing import (
     get_dataset_stats,
     create_normalized_chunks,
 )
-from src.pipelines.eval import evaluate_open_loop, evaluate_policy_mpc
+from src.pipelines.eval import evaluate_open_loop
 from matplotlib import pyplot as plt
 
 
-def train(config, args, dataset, logger):
+def train(config, args, dataset, logger=None, run_name="run"):
     # parsing some configs
     obs_dim = config.obs_dim
     action_dim = config.action_dim
@@ -109,16 +109,17 @@ def train(config, args, dataset, logger):
     optim = torch.optim.Adam(model.parameters(), lr=args.lr)
 
     # checkpoints and model saving
-    model_name = logger.run.name + ".pth"
+    model_name = f"{run_name}.pth"
     save_dir = "src/checkpoints"
     model_save_path = os.path.join(save_dir, model_name)
 
     pp = pprint.PrettyPrinter(indent=2)
     print("Training configuration:")
     pp.pprint(config)
-    print("Run name:", logger.run.name)
+    print("Run name:", run_name)
     print("Starting training...")
 
+    env = None
     for epoch in range(args.num_epochs):
         total_loss = 0.0
         total_chunks = 0
@@ -163,7 +164,15 @@ def train(config, args, dataset, logger):
             total_chunks += 1
 
         epoch_loss = total_loss / total_chunks if total_chunks > 0 else 0.0
-        logger.log({"epoch loss": epoch_loss})
+        if logger:
+            logger.log({"epoch loss": epoch_loss})
+        if args.eval_every and (epoch + 1) % args.eval_every == 0:
+            if env is None:
+                env = dataset.recover_environment()
+            fig, ax = evaluate_open_loop(
+                env, model, stats, input_dim, args, logger=logger
+            )
+            plt.close(fig)
         if (epoch + 1) % args.print_every == 0:
             elapsed = time.time() - start_time
             print(
@@ -173,7 +182,8 @@ def train(config, args, dataset, logger):
     print("Training complete. Saving model...")
     os.makedirs(save_dir, exist_ok=True)
     torch.save(model.state_dict(), model_save_path)
-    logger.save_model(model_save_path)
+    if logger:
+        logger.save_model(model_save_path)
     print(f"Model saved to {model_save_path}, training complete.")
     return model, stats, input_dim
 
@@ -194,31 +204,40 @@ def main():
     if args.environment == "LunarLander-v3":
         config = LunarLanderConfig()
     dataset = minari.load_dataset(dataset_id=config.dataset_name)
-    run_name = f"{args.environment}_{args.model_type}_h{args.horizon}_e{args.num_epochs}_k{args.kernel_size}_start_obs"
-    logger = WandBLogger(
-        config={
-            "environment": args.environment,
-            "horizon": args.horizon,
-            "batch_size": args.batch_size,
-            "model_type": args.model_type,
-            "hidden_dim": args.hidden_dim,
-            "kernel_size": (
-                args.kernel_size
-                if args.model_type == "cnn" or args.model_type == "ccnn"
-                else 0
-            ),
-            "num_epochs": args.num_epochs,
-            "lr": args.lr,
-        },
-        run_name=run_name,
+    cond = args.condition_on if args.condition_on else "none"
+    run_name = (
+        f"{args.environment}_{args.model_type}_h{args.horizon}_e{args.num_epochs}_"
+        f"k{args.kernel_size}_chunk-{args.chunk_type}_cond-{cond}"
     )
+    logger = None
+    if not args.no_wandb:
+        logger = WandBLogger(
+            config={
+                "environment": args.environment,
+                "horizon": args.horizon,
+                "batch_size": args.batch_size,
+                "model_type": args.model_type,
+                "hidden_dim": args.hidden_dim,
+                "kernel_size": (
+                    args.kernel_size
+                    if args.model_type == "cnn" or args.model_type == "ccnn"
+                    else 0
+                ),
+                "num_epochs": args.num_epochs,
+                "lr": args.lr,
+            },
+            run_name=run_name,
+        )
     model, stats, input_dim = train(
-        config=config, args=args, dataset=dataset, logger=logger
+        config=config, args=args, dataset=dataset, logger=logger, run_name=run_name
     )
     env = dataset.recover_environment()
-    fig, ax = evaluate_open_loop(env, model, stats, input_dim, args, logger=logger)
+    fig, ax = evaluate_open_loop(
+        env, model, stats, input_dim, args, logger=logger
+    )
     plt.close(fig)
-    logger.finish()
+    if logger:
+        logger.finish()
 
 
 if __name__ == "__main__":

--- a/src/utils/args.py
+++ b/src/utils/args.py
@@ -35,10 +35,26 @@ def parse_args() -> argparse.Namespace:
     training_args.add_argument("--batch-size", type=int, default=32)
     training_args.add_argument("--num-epochs", type=int, default=100)
     training_args.add_argument("--print-every", type=int, default=10)
+    training_args.add_argument(
+        "--eval-every",
+        type=int,
+        default=0,
+        help="Evaluate model every N epochs (0 to disable)",
+    )
     training_args.add_argument("--hidden-dim", type=int, default=128)
     training_args.add_argument("--lr", type=float, default=1e-3)
     training_args.add_argument(
-        "--model-type", type=str, default="ccnn", choices=["mlp", "cnn", "ccnn"]
+        "--model-type",
+        type=str,
+        default="ccnn",
+        choices=["mlp", "cnn", "ccnn", "unet"],
+    )
+    training_args.add_argument(
+        "--chunk-type",
+        type=str,
+        default="obs_act",
+        choices=["obs_act", "obs_only", "act_only"],
+        help="Type of data chunks to use",
     )
     training_args.add_argument(
         "--device", type=str, default="cuda" if torch.cuda.is_available() else "cpu"
@@ -71,8 +87,8 @@ def parse_args() -> argparse.Namespace:
     conditional_args.add_argument(
         "--condition-on",
         type=str,
-        default="reward",
-        choices=["reward", "start_obs"],
+        default=None,
+        choices=["reward", "start_obs", "start_obs_goal"],
         help="Condition type for trajectory generation.",
     )
     return parser.parse_args()


### PR DESCRIPTION
## Summary
- support UNet and chunk-type selection via new CLI args
- allow optional conditioning and new `start_obs_goal` mode
- add evaluation frequency flag and gate W&B on `--no-wandb`
- drop unused policy evaluation import after merging with main

## Testing
- `python3 -m py_compile src/utils/args.py src/run.py`
- `python3 -m pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a250002da883278a52f3122c6e4220